### PR TITLE
Update security disclosure medium

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ If you discover a security vulnerability, please review these guidelines before 
 
 While working to identify potential security vulnerabilities, we ask that you:
 
-- Share any issues you discover with us via [Github](https://github.com/craftcms/cms/security/advisories) or [our website](https://craftcms.com/contact) as soon as possible.
+- Share any issues you discover with us via [our website](https://craftcms.com/contact) as soon as possible.
 - Give us a reasonable amount of time to address any reported issues before publicizing them.
 - Only report issues that are [in scope](#scope).
 - Provide a quality report with precise explanations and concrete attack scenarios.


### PR DESCRIPTION
There appears to be no way for me to disclose a security issue within GitHub. The security advisories page is seemingly read only and meant for maintainers.