### PR TITLE
Update `innocarpe/actions-slack` to v1.1

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ inputs.success }}
     steps:
       - name: Notify Slack
-        uses: innocarpe/actions-slack@v1
+        uses: innocarpe/actions-slack@v1.1
         with:
           status: 'success'
           success_text: '${{ inputs.success_text_prefix }} ${{ inputs.success_text }}'
@@ -62,7 +62,7 @@ jobs:
     if: ${{ inputs.failure }}
     steps:
       - name: Notify Slack
-        uses: innocarpe/actions-slack@v1
+        uses: innocarpe/actions-slack@v1.1
         with:
           status: 'failure'
           success_text: '${{ inputs.success_text_prefix }} ${{ inputs.success_text }}'
@@ -77,7 +77,7 @@ jobs:
     if: ${{ !inputs.success && !inputs.failure }}
     steps:
       - name: Notify Slack
-        uses: innocarpe/actions-slack@v1
+        uses: innocarpe/actions-slack@v1.1
         with:
           status: 'cancelled'
           success_text: '${{ inputs.success_text_prefix }} ${{ inputs.success_text }}'


### PR DESCRIPTION
### Description
Currently, when slack is notified there is a warning showing up in the action. 

![](https://p191.p3.n0.cdn.getcloudapp.com/items/z8uLB28N/c7d92ecd-bf6c-4b3d-8994-8e69d93e12f6.png?v=830990a3dba9b23edf08f6b411031af1)

This was fixed in [1.1 of innocarpe/actions-slack](https://github.com/innocarpe/actions-slack/releases/tag/v1.1).
