### PR TITLE
[v3] Syntax Warning

### DIFF
--- a/.github/workflows/codecept.yml
+++ b/.github/workflows/codecept.yml
@@ -126,5 +126,5 @@ jobs:
         run: ${{ env.TEST_COMMAND }}
       # Only upload code coverage in specific scenarios
       - name: Upload coverage to Codecov
-        if: ${{ (matrix.php-versions == '8.1' || matrix.php-versions == '8.2') && matrix.db == 'mysql' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') }}}}
+        if: ${{ (matrix.php-versions == '8.1' || matrix.php-versions == '8.2') && matrix.db == 'mysql' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') }}
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
### Description
Noticed there is the following syntax warning. This change should fix it.

> [Workflow syntax warning: craftcms/.github/.github/workflows/ci.yml@v3#L55](https://github.com/craftcms/shopify/commit/9b8ddb1cc86367a7d78835c49aabc8776bdce8d0#annotation_59524016574)
In craftcms/.github/.github/workflows/ci.yml@v3 (Line: 55, Col: 11): Error from called workflow craftcms/.github/.github/workflows/codecept.yml@c87e7ff81bfc7825b3dec1789df7f7dde81fa05f (Line: 129, Col: 13): Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?