### PR TITLE
Add reusable PR Slack notification workflow

### DIFF
--- a/.github/workflows/notify-craft-cloud-review.yml
+++ b/.github/workflows/notify-craft-cloud-review.yml
@@ -1,0 +1,41 @@
+name: Notify Craft Cloud review requests
+
+on:
+  workflow_call:
+    secrets:
+      slack_webhook_url:
+        required: true
+
+permissions: {}
+
+jobs:
+  notify:
+    if: github.event.requested_team.slug == 'craft-cloud'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          jq -n \
+            --arg author "$PR_AUTHOR" \
+            --arg number "$PR_NUMBER" \
+            --arg repository "$REPOSITORY" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            '{
+              text: "Craft Cloud review requested",
+              blocks: [
+                {type: "section", text: {type: "mrkdwn", text: ("*Review requested:* <" + $url + "|" + $repository + " #" + $number + ">")}},
+                {type: "section", text: {type: "plain_text", text: ($title + " — by @" + $author), emoji: true}}
+              ]
+            }' |
+            curl --fail-with-body --silent --show-error \
+              --header 'Content-type: application/json' \
+              --data @- \
+              "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/pr-slack-notification.yml
+++ b/.github/workflows/pr-slack-notification.yml
@@ -1,4 +1,4 @@
-name: Notify Craft Cloud review requests
+name: PR Slack Notification
 
 on:
   workflow_call:
@@ -10,7 +10,6 @@ permissions: {}
 
 jobs:
   notify:
-    if: github.event.requested_team.slug == 'craft-cloud'
     runs-on: ubuntu-latest
     steps:
       - name: Post to Slack
@@ -29,9 +28,9 @@ jobs:
             --arg title "$PR_TITLE" \
             --arg url "$PR_URL" \
             '{
-              text: "Craft Cloud review requested",
+              text: "Pull request notification",
               blocks: [
-                {type: "section", text: {type: "mrkdwn", text: ("*Review requested:* <" + $url + "|" + $repository + " #" + $number + ">")}},
+                {type: "section", text: {type: "mrkdwn", text: ("*Pull request:* <" + $url + "|" + $repository + " #" + $number + ">")}},
                 {type: "section", text: {type: "plain_text", text: ($title + " — by @" + $author), emoji: true}}
               ]
             }' |

--- a/.github/workflows/pr-slack-notification.yml
+++ b/.github/workflows/pr-slack-notification.yml
@@ -21,6 +21,8 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          set -o pipefail
+
           jq -n \
             --arg author "$PR_AUTHOR" \
             --arg number "$PR_NUMBER" \


### PR DESCRIPTION
### Description

Adds a reusable workflow that posts pull request details to a configured Slack webhook. Calling workflows decide which pull request events and conditions should trigger a notification.

### Related issues

None.